### PR TITLE
added property levels to config

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -70,7 +70,7 @@ class WinstonTcpGraylog extends winston.Transport {
       'log': 6,
       'debug': 7
     }
-    this._levelMap = extend(myMap, this._config.levelMap)
+    this._levelMap = extend(myMap, (this._config.levelMap || this._config.levels))
 
     wtgDebug('levelMap: %j', this._levelMap)
     return this


### PR DESCRIPTION
The property that winston uses to create custom levels is `levels`. I had to dig quite deeply to debug, that winston-tcp-graylog uses `levelMap`. This commit adds the possibility to use both.