### PR TITLE
Fixed condition where short_message is not defined

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,2 @@
-*
-!/src-build/**
+#*
+#!/src-build/**

--- a/src/index.es6
+++ b/src/index.es6
@@ -137,7 +137,7 @@ class WinstonTcpGraylog extends winston.Transport {
       .split(/[\r\t\n]/)
       .filter(v => isString(v) && (trim(v).length > 0))[0]
 
-    if (short_message.length === 0) {
+    if (!short_message || short_message.length === 0) {
       let res = `WinstonTcpGraylog#handler skip: catch empty message: \
         \n\t fmtMsg: ${fmtMsg} \
         \n\t rawMeta: ${inspect(rawMeta)}`


### PR DESCRIPTION
Sometimes short_message can become undefined/null and the logger fails then at line 140 in src/index.es6. Fixed that.