### PR TITLE
Handle case when stripped message is `undefined`

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -137,7 +137,7 @@ class WinstonTcpGraylog extends winston.Transport {
       .split(/[\r\t\n]/)
       .filter(v => isString(v) && (trim(v).length > 0))[0]
 
-    if (short_message.length === 0) {
+    if (!short_message || short_message.length === 0) {
       let res = `WinstonTcpGraylog#handler skip: catch empty message: \
         \n\t fmtMsg: ${fmtMsg} \
         \n\t rawMeta: ${inspect(rawMeta)}`


### PR DESCRIPTION
When logging an empty string, the `short_message` variable is `undefined`. When trying to access `length` property, it crashes (`cannot get property length of undefined`).

I'm adding a check to handle that case.